### PR TITLE
Date range

### DIFF
--- a/music_this_week_app/backend/eventFinder.py
+++ b/music_this_week_app/backend/eventFinder.py
@@ -71,28 +71,35 @@ class EventFinder(object):
         self.generateListOfArtists()
 
     def assembleRequest(self, searchArgs, pageNum, count_only = False):
-        '''Receives search parameters and returns a URL for the endpoint'''
-	parsedDate = self.parseDate(searchArgs['start'], searchArgs['end'])
+        """
+        Receives search parameters and returns a URL for the endpoint
+
+        :param searchArgs: Dictionary of eventful search arguements
+        :param pageNum: Eventful page number
+        :param count_only: Flag for returning all results or just the number of results
+        :return URL: Eventful endpoint with the appropriate parameters
+        """
         filters = [ '',
                     'category=music', #seems to return the same results for music or concerts, so this might be unnecessary
                     'location=%s' %searchArgs['location'],
-                    'date=%s' %parsedDate,
+                    'date=%s' %self.parseDate(searchArgs['start'], searchArgs['end']),
                     'page_size=%s' %EVENTFUL_RESULTS_PER_PAGE,
                     'page_number=%s' %pageNum,
                     'sort_order=popularity' #Customer Support says this should work but I see no evidence of it working
                    ]
         filterString = '&'.join(filters + ['count_only=true'] if count_only else filters)
-
-
         baseURL = 'http://api.eventful.com/json/events/search?app_key=%s' % EVENTFUL_KEY
-
         URL = baseURL + filterString
-
         return URL
 
     def parseDate(self, start, end):
-        parsedDate = re.sub('-', '', start) + '00-' + re.sub('-','', end) + '00'
-        return parsedDate
+        """
+        Converts the start and end dates from the HTML widget into eventful format
+        :param start: String, search range start date with format YYYY-MM-DD
+        :param end: String, search range end date with format YYYY-MM-DD
+        :return parsedDate: String, search range with format YYYYMMDD00-YYYYMMDD00
+        """
+        return re.sub('-', '', start) + '00-' + re.sub('-','', end) + '00'
 
     def sendRequest(self, endpoint):
         """Send the search query to Eventful"""

--- a/music_this_week_app/backend/eventFinder.py
+++ b/music_this_week_app/backend/eventFinder.py
@@ -8,6 +8,7 @@ Nick Speal 2016
 import requests
 import os
 from datetime import datetime
+import re
 
 EVENTFUL_RESULTS_PER_PAGE = 50  # (I think it is max 100, default 20)
 
@@ -71,11 +72,11 @@ class EventFinder(object):
 
     def assembleRequest(self, searchArgs, pageNum, count_only = False):
         '''Receives search parameters and returns a URL for the endpoint'''
-
+	parsedDate = self.parseDate(searchArgs['start'], searchArgs['end'])
         filters = [ '',
                     'category=music', #seems to return the same results for music or concerts, so this might be unnecessary
                     'location=%s' %searchArgs['location'],
-                    'date=%s' %searchArgs['date'],
+                    'date=%s' %parsedDate,
                     'page_size=%s' %EVENTFUL_RESULTS_PER_PAGE,
                     'page_number=%s' %pageNum,
                     'sort_order=popularity' #Customer Support says this should work but I see no evidence of it working
@@ -88,6 +89,10 @@ class EventFinder(object):
         URL = baseURL + filterString
 
         return URL
+
+    def parseDate(self, start, end):
+        parsedDate = re.sub('-', '', start) + '00-' + re.sub('-','', end) + '00'
+        return parsedDate
 
     def sendRequest(self, endpoint):
         """Send the search query to Eventful"""

--- a/music_this_week_app/templates/music_this_week/setup.html
+++ b/music_this_week_app/templates/music_this_week/setup.html
@@ -13,7 +13,7 @@
         <p><span style="text-decoration: underline;">Search Arguments:</span></p>
         <form action="/search" id="form">
             <p><strong>Location:</strong> <input id = "loc_field" type="text" name="location" value="San Francisco"></p>
-            <p><strong>Time range:</strong> <input id = "date_field" type="text" name="date" value="Next 7 Days"></p>
+            <p><strong>Time range:</strong> <input id = "start-date" type="date" name="start">   to   <input id = "end_date" type="date" name="end"></p>
             <input hidden=true name="nResults" value="200">
             <button type="submit" id="search-button" onclick="buttonClick(this.form)">Search</button>
         </form>

--- a/music_this_week_app/templates/music_this_week/setup.html
+++ b/music_this_week_app/templates/music_this_week/setup.html
@@ -13,7 +13,7 @@
         <p><span style="text-decoration: underline;">Search Arguments:</span></p>
         <form action="/search" id="form">
             <p><strong>Location:</strong> <input id = "loc_field" type="text" name="location" value="San Francisco"></p>
-            <p><strong>Time range:</strong> <input id = "start-date" type="date" name="start">   to   <input id = "end_date" type="date" name="end"></p>
+            <p><strong>Date Range:</strong> <input id = "start_date" type="date" name="start">   to   <input id = "end_date" type="date" name="end"></p>
             <input hidden=true name="nResults" value="200">
             <button type="submit" id="search-button" onclick="buttonClick(this.form)">Search</button>
         </form>
@@ -22,6 +22,24 @@
     </div>
 
     <script>
+        /* Populate date range fields */
+
+        var start = new Date();
+        var end = new Date();
+
+        // Offset end date by desired number of days
+        end.setDate(start.getDate() + 7);
+
+        // Format strings for the date elements:
+        var start_formatted = start.toJSON().slice(0,10);
+        var end_formatted = end.toJSON().slice(0,10);
+
+        // Set element values
+        document.getElementById('start_date').value = start_formatted;
+        document.getElementById('end_date').value = end_formatted;
+
+
+        /* Search Button */
         //When Search button is pressed, change the UI and then submit the request.
         function buttonClick(form) {
             document.getElementById('search-button').innerHTML = "Searching...";

--- a/music_this_week_app/tests/test_integration.py
+++ b/music_this_week_app/tests/test_integration.py
@@ -7,8 +7,9 @@ from music_this_week_app.backend.spotifyHandler import PlaylistCreator
 class test_integrations(TestCase):
     def setUp(self):
         self.search_args = {'location': 'San+Francisco',
-                       'date': 'next+7+days',
-                       'nResults': '100'}
+                            'start': '2016082100',
+                            'end': '2016082800',
+                            'nResults': '100'}
 
     def test_integration_end_to_end(self):
         """test end to end flow"""

--- a/music_this_week_app/views.py
+++ b/music_this_week_app/views.py
@@ -95,7 +95,7 @@ def search(request):
     search_args = dict(request.GET.items())
 
     #Validate search arguments
-    if "location" not in search_args.keys() or "date" not in search_args.keys() or "nResults" not in search_args.keys():
+    if "location" not in search_args.keys() or search_args["start"] == '' or search_args["end"] =='' or  "nResults" not in search_args.keys():
         print("ERROR: Bad search arguments")
         print(search_args)
         resp = HttpResponse("Bad Search Arguments")

--- a/music_this_week_app/views.py
+++ b/music_this_week_app/views.py
@@ -95,7 +95,7 @@ def search(request):
     search_args = dict(request.GET.items())
 
     #Validate search arguments
-    if "location" not in search_args.keys() or search_args["start"] == '' or search_args["end"] =='' or  "nResults" not in search_args.keys():
+    if "location" not in search_args.keys() or search_args["start"] == '' or search_args["end"] == '' or "nResults" not in search_args.keys():
         print("ERROR: Bad search arguments")
         print(search_args)
         resp = HttpResponse("Bad Search Arguments")


### PR DESCRIPTION
Allow users to specify a specific range of dates rather than a vague search string like "Next 7 days."
- Ported code from #10 
- Pre-populates fields with today's date plus 7 days
- Tested on OSX with Chrome and iOS with Safari and the UI looks fine on both.

Resolves #8 
