### PR TITLE
Update login asset source to speal.ca

### DIFF
--- a/music_this_week_app/templates/music_this_week/home.html
+++ b/music_this_week_app/templates/music_this_week/home.html
@@ -6,6 +6,6 @@
 <body>
     <h1 style="text-align: center;">Welcome to Music This Week!</h1>
     <p style="text-align: center;">This app generates a Spotify playlist of bands that are playing in your area in the near future.</p>
-    <p style="text-align: center;"><a title="Login" href="/login"><img src="https://addtotop.maki-chan.de/assets/img/login-button-mobile.png" alt="Login with Spotify" width="488" height="88" /></a></p>
+    <p style="text-align: center;"><a title="Login" href="/login"><img src="http://www.speal.ca/images/music_this_week/spotify_login.svg" alt="Login with Spotify" width="488" height="88" /></a></p>
 </body>
 </html>


### PR DESCRIPTION
Quick fix for #28 

The login with Spotify image has been a broken link for a while because the source changed to have an invalid certificate or something. 

Ideally I'd like to set up an apache webserver to serve static assets, and that's something I'm working on but is not yet ready. I made this small change just to fix it in the short term. The image is now hosted by github pages at on the speal.ca main page.
